### PR TITLE
Added ReplaceHeaders and ReplaceRules functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     * [Beginning with opendkim](#beginning-with-opendkim)
     * [Add domains for signing](#add-domains-for-signing)
     * [Add allowed hosts](#add-allowed-hosts)
+    * [Add replace rules](#add-replace-rules)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
@@ -32,6 +33,8 @@ This includes the ability to configure and manage a range of different domain, a
 * package/service/configuration files for OpenDKIM
 * signing domains list
 * trusted hosts list
+* replace headers list
+* replace rules list
 
 ### Beginning with opendkim
 
@@ -43,10 +46,18 @@ To install OpenDKIM with the default parameters
 
     opendkim::domain{['example.com', 'example.org']:}
 
-
 ### Add allowed hosts
 
     opendkim::trusted{['10.0.0.0/8', '203.0.113.0/24']:}
+
+### Add replace rules
+
+    # replace_rules_domain should NOT be defined as the title of a resource body
+    # if it's an array (i.e. if you have multiple domains to rewrite)
+    opendkim::replace { 'rewrite-multiple-domains':
+      replace_rules_domain => ['example.com', 'example.org'],
+      replace_rules_array => ['example.net', 'example.biz'],
+    }
 
 ## Usage
 
@@ -76,6 +87,7 @@ This host signs all mails for domains example.com and example.org.
     include opendkim
     opendkim::domain{['example.com', 'example.org']:}
     opendkim::trusted{['10.0.0.0/8', '203.0.113.0/24']:}
+    opendkim::replace {'example.com': replace_rules_array => ['example.net', 'example.biz'],}
 
 After puppet-run you need to copy contents of  /etc/opendkim/keys/example.com/relay-site.txt and paste into corresponding DNS-zone as TXT.
 Then repeat this action for example.org

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,93 +13,95 @@
 # Copyright 2015 Vladimir Bykanov
 #
 class opendkim (
-    $autorestart          = 'Yes',
-    $autorestart_rate     = '10/1h',
-    $log_why              = 'Yes',
-    $syslog               = 'Yes',
-    $syslog_success       = 'Yes',
-    $mode                 = 's',
-    $canonicalization     = 'relaxed/simple',
-    $external_ignore_list = 'refile:/etc/opendkim/TrustedHosts',
-    $internal_hosts       = 'refile:/etc/opendkim/TrustedHosts',
-    $keytable             = 'refile:/etc/opendkim/KeyTable',
-    $signing_table        = 'refile:/etc/opendkim/SigningTable',
-    $signature_algorithm  = 'rsa-sha256',
-    $socket               = 'inet:8891@localhost',
-    $pidfile              = '/var/run/opendkim/opendkim.pid',
-    $umask                = '022',
-    $userid               = 'opendkim:opendkim',
-    $temporary_directory  = '/var/tmp',
-    $package_name         = 'opendkim',
-    $service_name         = 'opendkim',
-    $pathconf             = '/etc/opendkim',
-    $owner                = 'opendkim',
-    $group                = 'opendkim',
-) {
+  $autorestart          = 'Yes',
+  $autorestart_rate     = '10/1h',
+  $log_why              = 'Yes',
+  $syslog               = 'Yes',
+  $syslog_success       = 'Yes',
+  $mode                 = 's',
+  $canonicalization     = 'relaxed/simple',
+  $external_ignore_list = 'refile:/etc/opendkim/TrustedHosts',
+  $internal_hosts       = 'refile:/etc/opendkim/TrustedHosts',
+  $keytable             = 'refile:/etc/opendkim/KeyTable',
+  $signing_table        = 'refile:/etc/opendkim/SigningTable',
+  $signature_algorithm  = 'rsa-sha256',
+  $socket               = 'inet:8891@localhost',
+  $pidfile              = '/var/run/opendkim/opendkim.pid',
+  $umask                = '022',
+  $userid               = 'opendkim:opendkim',
+  $temporary_directory  = '/var/tmp',
+  $package_name         = 'opendkim',
+  $service_name         = 'opendkim',
+  $pathconf             = '/etc/opendkim',
+  $owner                = 'opendkim',
+  $group                = 'opendkim',
+  $replace_headers      = '/etc/opendkim/ReplaceHeaders',
+  $replace_rules        = '/etc/opendkim/ReplaceRules',) {
+  package { $package_name: ensure => present, }
 
-    package { $package_name:
-        ensure => present,
-    }
+  case $::operatingsystem {
+    /^(Debian|Ubuntu)$/ : {
+      package { 'opendkim-tools': ensure => present, }
 
-    case $::operatingsystem {
-      /^(Debian|Ubuntu)$/: {
-            package { 'opendkim-tools':
-              ensure => present,
-            }
-            # Debian/Ubuntu doesn't ship this directory in its package
-            file { $pathconf:
-              ensure  => directory,
-              owner   => 'root',
-              group   => 'opendkim',
-              mode    => '0755',
-              require => Package[$package_name],
-            }
-            file { "${pathconf}/keys":
-              ensure  => directory,
-              owner   => 'opendkim',
-              group   => 'opendkim',
-              mode    => '0750',
-              require => Package[$package_name],
-            }
-            file { "${pathconf}/KeyTable":
-              ensure  => present,
-              owner   => 'opendkim',
-              group   => 'opendkim',
-              mode    => '0640',
-              require => Package[$package_name],
-            }
-            file { "${pathconf}/SigningTable":
-              ensure  => present,
-              owner   => 'opendkim',
-              group   => 'opendkim',
-              mode    => '0640',
-              require => Package[$package_name],
-            }
-            file { "${pathconf}/TrustedHosts":
-              ensure  => present,
-              owner   => 'opendkim',
-              group   => 'opendkim',
-              mode    => '0644',
-              require => Package[$package_name],
-            }
-      }
-      default: {}
-    }
-
-    file {'/etc/opendkim.conf':
-        ensure  => file,
+      # Debian/Ubuntu doesn't ship this directory in its package
+      file { $pathconf:
+        ensure  => directory,
         owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        content => template('opendkim/opendkim.conf'),
-        notify  => Service[$service_name],
+        group   => 'opendkim',
+        mode    => '0755',
         require => Package[$package_name],
-    }
+      }
 
-    service { $service_name:
-        ensure  => running,
-        enable  => true,
+      file { "${pathconf}/keys":
+        ensure  => directory,
+        owner   => 'opendkim',
+        group   => 'opendkim',
+        mode    => '0750',
         require => Package[$package_name],
+      }
+
+      file { "${pathconf}/KeyTable":
+        ensure  => present,
+        owner   => 'opendkim',
+        group   => 'opendkim',
+        mode    => '0640',
+        require => Package[$package_name],
+      }
+
+      file { "${pathconf}/SigningTable":
+        ensure  => present,
+        owner   => 'opendkim',
+        group   => 'opendkim',
+        mode    => '0640',
+        require => Package[$package_name],
+      }
+
+      file { "${pathconf}/TrustedHosts":
+        ensure  => present,
+        owner   => 'opendkim',
+        group   => 'opendkim',
+        mode    => '0644',
+        require => Package[$package_name],
+      }
     }
+    default             : {
+    }
+  }
+
+  file { '/etc/opendkim.conf':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('opendkim/opendkim.conf'),
+    notify  => Service[$service_name],
+    require => Package[$package_name],
+  }
+
+  service { $service_name:
+    ensure  => running,
+    enable  => true,
+    require => Package[$package_name],
+  }
 }
 

--- a/manifests/replace.pp
+++ b/manifests/replace.pp
@@ -1,0 +1,32 @@
+define opendkim::replace (
+  # replace_rules_domain should NOT be defined as the title of a resource body
+  # if it's an array (i.e. if you have multiple domains to rewrite)
+  $replace_rules_domain     = $name,
+  $replace_headers_array    = ['from'],
+  $replace_headers_template = 'opendkim/ReplaceHeaders',
+  $replace_rules_array      = [],
+  $replace_rules_template   = 'opendkim/ReplaceRules',
+  # if FEATURE(`masquerade_entire_domain') enabled in sendmail
+  $masq_entire_domain       = true,) {
+  if ( is_array($replace_rules_array) ) and ( size($replace_rules_array) > 0 ) {
+    file { $opendkim::replace_rules:
+      ensure  => file,
+      owner   => $opendkim::owner,
+      group   => $opendkim::group,
+      mode    => '0640',
+      content => template($replace_rules_template),
+      notify  => Service[$opendkim::service_name],
+      require => Package[$opendkim::package_name],
+    }
+
+    file { $opendkim::replace_headers:
+      ensure  => file,
+      owner   => $opendkim::owner,
+      group   => $opendkim::group,
+      mode    => '0640',
+      content => template($replace_headers_template),
+      notify  => Service[$opendkim::service_name],
+      require => Package[$opendkim::package_name],
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -10,18 +10,45 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [ "5", "6", "7" ]
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [ "5", "6", "7" ]
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     }
   ],
   "dependencies": [
     {
-      "name": "stahnma/epel",
+      "name": "stahnma-epel",
       "version_requirement": ">= 1.0.0"
     }
-  ]
-}
+  ],
+  "description": "UNKNOWN",
+  "types": [
 
+  ],
+  "checksums": {
+    "Gemfile": "19456e851851a3bd7aa6729108429dde",
+    "LICENSE": "fa818a259cbed7ce8bc2a22d35a464fc",
+    "Modulefile": "9a3b46c73c1ae7309fe2d35c5e6fa549",
+    "Puppetfile": "607001b25e4f9d020b2ce4444174a654",
+    "README.md": "0764cc9bb9de221c97bce2664ba99657",
+    "Rakefile": "a162d9397ed53fa8fa49c57609feedcb",
+    "manifests/domain.pp": "61f78cbd4376e58a7b26f1298f38804b",
+    "manifests/init.pp": "4987dcd9ebc88e7ea0de3b74c9af6d9c",
+    "manifests/trusted.pp": "bcc132622e2c2e39bcbc3116c7788c8b",
+    "spec/classes/init_spec.rb": "0451831b29191c21b2cdc045c94a2243",
+    "spec/classes/opendkim_spec.rb": "9f06a3f005344875a0fb5753ab43cb34",
+    "spec/spec_helper.rb": "0db89c9a486df193c0e40095422e19dc",
+    "templates/opendkim.conf": "047e76e4c2a0a15754101f2da32ab2fe",
+    "tests/init.pp": "8c9ab8c85cd89dae1ad97cbe949a7e6e"
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -10,45 +10,17 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": [ "5", "6", "7" ]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": [ "5", "6", "7" ]
     }
   ],
   "dependencies": [
     {
-      "name": "stahnma-epel",
+      "name": "stahnma/epel",
       "version_requirement": ">= 1.0.0"
     }
-  ],
-  "description": "UNKNOWN",
-  "types": [
-
-  ],
-  "checksums": {
-    "Gemfile": "19456e851851a3bd7aa6729108429dde",
-    "LICENSE": "fa818a259cbed7ce8bc2a22d35a464fc",
-    "Modulefile": "9a3b46c73c1ae7309fe2d35c5e6fa549",
-    "Puppetfile": "607001b25e4f9d020b2ce4444174a654",
-    "README.md": "0764cc9bb9de221c97bce2664ba99657",
-    "Rakefile": "a162d9397ed53fa8fa49c57609feedcb",
-    "manifests/domain.pp": "61f78cbd4376e58a7b26f1298f38804b",
-    "manifests/init.pp": "4987dcd9ebc88e7ea0de3b74c9af6d9c",
-    "manifests/trusted.pp": "bcc132622e2c2e39bcbc3116c7788c8b",
-    "spec/classes/init_spec.rb": "0451831b29191c21b2cdc045c94a2243",
-    "spec/classes/opendkim_spec.rb": "9f06a3f005344875a0fb5753ab43cb34",
-    "spec/spec_helper.rb": "0db89c9a486df193c0e40095422e19dc",
-    "templates/opendkim.conf": "047e76e4c2a0a15754101f2da32ab2fe",
-    "tests/init.pp": "8c9ab8c85cd89dae1ad97cbe949a7e6e"
-  }
+  ]
 }

--- a/templates/ReplaceHeaders
+++ b/templates/ReplaceHeaders
@@ -1,0 +1,3 @@
+<% @replace_headers_array.sort.each do |replace_header| -%>
+<%= replace_header %>
+<% end -%>

--- a/templates/ReplaceRules
+++ b/templates/ReplaceRules
@@ -1,0 +1,21 @@
+<% if @replace_rules_domain.class == 'Array' -%>
+<% @replace_rules_domain.sort.each do |replace_domain| -%>
+<% @replace_rules_array.sort.each do |replace_rule| -%>
+<% if @masq_entire_domain == true -%>
+@.*\.<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= replace_domain %>
+<% end -%>
+<% if replace_rule != replace_domain -%>
+@<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= replace_domain %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% else -%>
+<% @replace_rules_array.sort.each do |replace_rule| -%>
+<% if @masq_entire_domain == true -%>
+@.*\.<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= @replace_rules_domain %>
+<% end -%>
+<% if replace_rule != @replace_rules_domain -%>
+@<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= @replace_rules_domain %>
+<% end -%>
+<% end -%>
+<% end -%>

--- a/templates/ReplaceRules
+++ b/templates/ReplaceRules
@@ -2,20 +2,20 @@
 <% @replace_rules_domain.sort.each do |replace_domain| -%>
 <% @replace_rules_array.sort.each do |replace_rule| -%>
 <% if @masq_entire_domain == true -%>
-@.*\.<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= replace_domain %>
+@.*\.<%= replace_rule.gsub(/\./, "\\\.") -%>\(>\)\?$	@<%= replace_domain %>
 <% end -%>
 <% if replace_rule != replace_domain -%>
-@<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= replace_domain %>
+@<%= replace_rule.gsub(/\./, "\\\.") -%>\(>\)\?$	@<%= replace_domain %>
 <% end -%>
 <% end -%>
 <% end -%>
 <% else -%>
 <% @replace_rules_array.sort.each do |replace_rule| -%>
 <% if @masq_entire_domain == true -%>
-@.*\.<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= @replace_rules_domain %>
+@.*\.<%= replace_rule.gsub(/\./, "\\\.") -%>\(>\)\?$	@<%= @replace_rules_domain %>
 <% end -%>
 <% if replace_rule != @replace_rules_domain -%>
-@<%= replace_rule.gsub(/\./, "\\\.") -%>	@<%= @replace_rules_domain %>
+@<%= replace_rule.gsub(/\./, "\\\.") -%>\(>\)\?$	@<%= @replace_rules_domain %>
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/opendkim.conf
+++ b/templates/opendkim.conf
@@ -49,4 +49,9 @@ UserID <%= @userid %>
 <%- if @temporary_directory -%>
 TemporaryDirectory <%= @temporary_directory %>
 <%- end -%>
-
+<%- if @replace_headers -%>
+ReplaceHeaders <%= @replace_headers %>
+<%- end -%>
+<%- if @replace_rules -%>
+ReplaceRules <%= @replace_rules %>
+<%- end -%>


### PR DESCRIPTION
Hi Vladimir,
Thank you for your module - it saved me time :) Hope, my pull request can be useful.
I use ReplaceHeaders and ReplaceRules to sign messages which will be masqueraded by sendmail, i.e. when the following exists in "/etc/mail/sendmail.mc"

```
MASQUERADE_AS(`example.com')dnl
MASQUERADE_DOMAIN(`example.com example.org example.net')dnl
FEATURE(`masquerade_envelope')dnl
FEATURE(`masquerade_entire_domain')dnl
```

For CentOS 6 opendkim RPM should be re-built to enable this functionality

```
diff -u ./opendkim-2.10.3/opendkim/opendkim-config.h.bak ./opendkim-2.10.3/opendkim/opendkim-config.h
--- opendkim-config.h.bak       2016-04-19 10:58:33.746001946 +0100
+++ opendkim-config.h   2016-04-19 11:02:20.024353330 +0100
@@ -144,6 +144,7 @@
        { "RemoveARFrom",               CONFIG_TYPE_STRING,     FALSE },
        { "RemoveOldSignatures",        CONFIG_TYPE_BOOLEAN,    FALSE },
 #ifdef _FFR_REPLACE_RULES
+       { "ReplaceHeaders",             CONFIG_TYPE_STRING,     FALSE },
        { "ReplaceRules",               CONFIG_TYPE_STRING,     FALSE },
 #endif /* _FFR_REPLACE_RULES */
        { "ReportAddress",              CONFIG_TYPE_STRING,     FALSE },

diff -u ./opendkim.spec.bak /opendkim.spec
--- opendkim.spec       2015-12-26 01:17:22.000000000 +0000
+++ ./rpmbuild/SPECS/opendkim.spec      2016-04-18 10:48:51.504291368 +0100
@@ -83,7 +83,7 @@
 %configure --with-odbx --with-db --with-libmemcached --with-openldap
 %else
 # Configure with options available to SysV
-%configure --with-odbx --with-db --with-openldap
+%configure --with-odbx --with-db --with-openldap --enable-replace_rules
 %endif

 # Remove rpath
```
