### PR TITLE
Euid fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake'
+gem 'rake', '< 11.0'
 gem 'puppet-lint'
 gem 'rspec-puppet'
 gem 'rspec-system-puppet'


### PR DESCRIPTION
Fixes for opendkim to be able running with alternate UID/GID on Debian/Ubuntu. Essential for postfix, which requires opendkim's milter socket to be in its chrooted environment. E.g.:

opendkim::socket: 'local:/var/spool/postfix/private/opendkim'
opendkim::userid: 'postfix:opendkim'
opendkim::owner:  'postfix'
opendkim::group:  'opendkim'
opendkim::mode: 'vs'
opendkim::replace_headers: false
opendkim::replace_rules: false